### PR TITLE
Bump capnp versions and fix resulting string conversion error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "capnp"
-version = "0.18.7"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3a3a3b1b6ad38dea0e945a9bc1524331b03ba1d07360bd437891fc86e14091"
+checksum = "de71387912cac7dd3cb7c219e09628411620a18061bba58c71453c26ae7bf66a"
 dependencies = [
  "embedded-io",
 ]
@@ -40,18 +40,18 @@ dependencies = [
 
 [[package]]
 name = "capnpc"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f3c8ee94d993d03150153e9a57a6ff330127b1c1ad76475051e1cef79c2d"
+checksum = "c75ba30e0f08582d53c2f3710cf4bb65ff562614b1ba86906d7391adffe189ec"
 dependencies = [
  "capnp",
 ]
 
 [[package]]
 name = "embedded-io"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "example"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/aikalant/capnp_conv"
 capnp_conv = { path = "capnp_conv", version = "0.3.0" }
 capnp_conv_macros = { path = "capnp_conv_macros", version = "0.3.0" }
 
-capnp = "0.18"
-capnpc = "0.18"
+capnp = "0.19"
+capnpc = "0.19"
 heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/capnp_conv_macros/src/generators.rs
+++ b/capnp_conv_macros/src/generators.rs
@@ -478,7 +478,7 @@ impl FieldType {
             FieldType::Void(_) => quote!(builder.#setter(())),
             FieldType::Primitive(_) => quote!(builder.#setter(#deref_field)),
             FieldType::Data(_) => quote!(builder.#setter(#ref_field)),
-            FieldType::Text(_) => quote!(builder.#setter(#field.as_str().into())),
+            FieldType::Text(_) => quote!(builder.#setter(#field.as_str())),
             FieldType::Struct(_) => quote!(#field.write(builder.reborrow().#initializer())),
             FieldType::EnumRemote(_) => {
                 quote!(builder.#setter(::capnp_conv::RemoteEnum::to_capnp_enum(#ref_field)))


### PR DESCRIPTION
This PR updates the capnp version used by capnp_conv, and fixes a small bug caused by the update in string conversion (apparently `set_text_val` accepts `AsRef<str>`, don't know if that changed recently or what).