### PR TITLE
upgrade to capnp 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 capnp_conv = { path = "capnp_conv", version = "0.3.1" }
 capnp_conv_macros = { path = "capnp_conv_macros", version = "0.3.1" }
 
-capnp = "0.19"
-capnpc = "0.19"
+capnp = "0.20"
+capnpc = "0.20"
 heck = "0.5"
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
They have recently updated Rust Cap'n proto to 0.20.x so this PR just updates the dependencies.

Also, thanks for the great work.