### PR TITLE
basic no_std support, as long as you avoid Text and Data and List

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 capnp_conv = { path = "capnp_conv", version = "0.3.1" }
 capnp_conv_macros = { path = "capnp_conv_macros", version = "0.3.1" }
 
-capnp = "0.20"
+capnp = { "version" = "0.20", default-features = false }
 capnpc = "0.20"
 heck = "0.5"
 proc-macro2 = "1.0"

--- a/capnp_conv/Cargo.toml
+++ b/capnp_conv/Cargo.toml
@@ -11,3 +11,7 @@ readme.workspace = true
 capnp_conv_macros.workspace = true
 
 capnp.workspace = true
+
+[features]
+default = ["std"]
+std = ["capnp/default"]

--- a/capnp_conv/src/lib.rs
+++ b/capnp_conv/src/lib.rs
@@ -1,5 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use capnp::{traits::Owned, Result};
 pub use capnp_conv_macros::capnp_conv;
+use core::marker::Sized;
 
 pub trait Writable {
     type OwnedType: Owned;

--- a/capnp_conv_macros/src/generators.rs
+++ b/capnp_conv_macros/src/generators.rs
@@ -571,7 +571,7 @@ fn generate_try_from_impl(
     let capnp_generics: Vec<Ident> = generics.iter().map(to_capnp_generic).collect();
     quote! {
       impl<'a, #(#generics, #capnp_generics),*>
-      ::std::convert::TryFrom<#capnp_path::Reader<'a, #(#capnp_generics),*>>
+      ::core::convert::TryFrom<#capnp_path::Reader<'a, #(#capnp_generics),*>>
       for #rust_name<#(#generics),*>
       where
         #(#generics: ::capnp_conv::Readable<OwnedType = #capnp_generics>,)*


### PR DESCRIPTION
After this patch, the capnp_conv macro works fine in a no_std environment.

I tested by adding `#![no_std]` to `example/src/main.rs` and then switching out all `Text`/`Data`/`List` fields in `example/example.capnp` with `Void`, and updating main.rs to use `()` and the `println!()` with `assert!()`.

If you would like me to add a no_std example folder, I can do. I haven't thought about how to handle `Text`/`Data`/`List` fields in on_std, because my current project doesn't need them. If you want to wait until we have a solution for those types before advertising no_std support, I guess we can just merge this patch as-is.